### PR TITLE
fix: remove colons from generated file-names

### DIFF
--- a/utils/id.go
+++ b/utils/id.go
@@ -16,7 +16,7 @@ import (
 func IDFromClusterAndContext(cluster, context string) string {
 	id := context + "_" + cluster
 
-	illegalChars := []string{"/"}
+	illegalChars := []string{"/", ":"}
 	for _, c := range illegalChars {
 		id = strings.ReplaceAll(id, c, "-")
 	}

--- a/utils/id_test.go
+++ b/utils/id_test.go
@@ -15,8 +15,10 @@ var validCombos = []struct {
 	id      string
 }{
 	{"dev-eu", "dev-eu-1", "dev-eu_dev-eu-1"},
-	{"con", "mygreathost.com:443", "con_mygreathost.com:443"},
-	{"host.com:443/with/slashes", "danger", "host.com:443-with-slashes_danger"},
+	{"con", "mygreathost.com-443", "con_mygreathost.com-443"},
+	{"host.com-443/with/slashes", "danger", "host.com-443-with-slashes_danger"},
+	{"host.com-443@something.nice", "danger", "host.com-443@something.nice_danger"},
+	{"this:would:break:on:windows", "danger", "this-would-break-on-windows_danger"},
 }
 
 func TestPathForID(t *testing.T) {


### PR DESCRIPTION
This fixes and issue on windows, where one colon in the filename is fine, but not multiple ones