### PR TITLE
feat: add silent flag to surpress log output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,8 +40,8 @@ source <(konf-go shellwrapper zsh)
 # Alias
 alias kctx="konf set"
 alias kns="konf ns"
-# Open last konf on new session
-export KUBECONFIG=$(konf-go set -)
+# Open last konf on new session (use --silent to suppress INFO log line)
+export KUBECONFIG=$(konf-go --silent set -)
 ```
 
 ## Usage
@@ -113,7 +113,6 @@ go test -run Integration ./...
 - Make it work for fish
 - Allow usage of other fuzzy finders like fzf
 - Add CI
-- `--silent` option for `set` command on which it does not log anything. This can be useful for things like `konf set -` when running it in every new session
 - `konf manage` so you can rename contexts and clusters
 - `konf delete` option so you can delete konfs you don't need anymore
 - figure out auto-completion. This might be a bit tricky due to the `konf` zsh func wrapper

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"strconv"
 
 	"github.com/mitchellh/go-ps"
+	log "github.com/simontheleg/konf-go/log"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -49,7 +49,7 @@ func selfClean(f afero.Fs) error {
 	err := f.Remove(fpath)
 
 	if errors.Is(err, fs.ErrNotExist) {
-		log.Printf("current konf '%s' was already deleted, nothing to self-cleanup\n", fpath)
+		log.Info("current konf '%s' was already deleted, nothing to self-cleanup\n", fpath)
 		return nil
 	}
 
@@ -77,7 +77,7 @@ func cleanLeftOvers(f afero.Fs) error {
 		sPid := utils.IDFromFileInfo(konf)
 		pid, err := strconv.Atoi(sPid)
 		if err != nil {
-			log.Printf("file '%s' could not be converted into an int, and therefore cannot be a valid process id. Skip for cleanup", konf.Name())
+			log.Warn("file '%s' could not be converted into an int, and therefore cannot be a valid process id. Skip for cleanup", konf.Name())
 			continue
 		}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
+	log "github.com/simontheleg/konf-go/log"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -69,7 +69,7 @@ func (c *importCmd) importf(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Imported konf from %q successfully into %q\n", fpath, conf.FilePath)
+		log.Info("Imported konf from %q successfully into %q\n", fpath, conf.FilePath)
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/simontheleg/konf-go/config"
+	"github.com/simontheleg/konf-go/log"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -12,6 +14,7 @@ import (
 var (
 	cfgFile string
 	konfDir string
+	silent  bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -38,6 +41,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.konfig.yaml)")
 	rootCmd.PersistentFlags().StringVar(&konfDir, "konfDir", "", "konfs directory for kubeconfigs and tracking active konfs (default is $HOME/.kube/konfs)")
+	rootCmd.PersistentFlags().BoolVar(&silent, "silent", false, "suppress log output if set to true (default is false)")
 
 }
 
@@ -45,6 +49,10 @@ func init() {
 func wrapInit() {
 	err := config.Init(cfgFile, konfDir)
 	cobra.CheckErr(err)
+
+	if silent {
+		log.InitLogger(io.Discard, io.Discard)
+	}
 
 	err = utils.EnsureDir(afero.NewOsFs())
 	cobra.CheckErr(err)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"strings"
 	"text/template"
 
 	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/manifoldco/promptui"
+	log "github.com/simontheleg/konf-go/log"
 	"github.com/simontheleg/konf-go/prompt"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
@@ -60,7 +60,7 @@ Examples:
 			return fmt.Errorf("could not save latest konf. As a result 'konf set -' might not work: %q ", err)
 		}
 
-		log.Printf("Setting context to %q\n", id)
+		log.Info("Setting context to %q\n", id)
 		// By printing out to stdout, we pass the value to our zsh hook, which then sets $KUBECONFIG to it
 		fmt.Println(context)
 
@@ -166,7 +166,7 @@ func fetchKonfs(f afero.Fs) ([]tableOutput, error) {
 		kubeconf := &k8s.Config{}
 		err = yaml.Unmarshal(val, kubeconf)
 		if err != nil {
-			log.Printf("file %q does not contain a valid kubeconfig. Skipping for evaluation", path)
+			log.Warn("file %q does not contain a valid kubeconfig. Skipping for evaluation", path)
 			continue
 		}
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,27 @@
+package log
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+var infoL *log.Logger
+var warnL *log.Logger
+
+func InitLogger(info, warn io.Writer) {
+	infoL = log.New(info, "INFO: ", 0)
+	warnL = log.New(warn, "WARN: ", 0)
+}
+
+func Info(format string, v ...interface{}) {
+	infoL.Printf(format, v...)
+}
+
+func Warn(format string, v ...interface{}) {
+	warnL.Printf(format, v...)
+}
+
+func init() {
+	InitLogger(os.Stderr, os.Stderr)
+}


### PR DESCRIPTION
This is useful for commands like 'set -' that can be used on shell starts, so they are not as spammy.