### PR TITLE
refactor: extract testhelper into separate package

### DIFF
--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/simontheleg/konf-go/config"
+	"github.com/simontheleg/konf-go/testhelper"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
 )
@@ -47,7 +48,7 @@ func TestSelfClean(t *testing.T) {
 
 			err := selfClean(tc.Fs)
 
-			if !utils.EqualError(err, tc.ExpError) {
+			if !testhelper.EqualError(err, tc.ExpError) {
 				t.Errorf("Want error '%s', got '%s'", tc.ExpError, err)
 			}
 
@@ -75,14 +76,14 @@ func TestSelfClean(t *testing.T) {
 func ppidFS() afero.Fs {
 	ppid := os.Getppid()
 	fs := ppidFileMissing()
-	sm := utils.SampleKonfManager{}
+	sm := testhelper.SampleKonfManager{}
 	afero.WriteFile(fs, utils.ActivePathForID(fmt.Sprint(ppid)), []byte(sm.SingleClusterSingleContextEU()), utils.KonfPerm)
 	return fs
 }
 
 func ppidFileMissing() afero.Fs {
 	fs := afero.NewMemMapFs()
-	sm := utils.SampleKonfManager{}
+	sm := testhelper.SampleKonfManager{}
 	afero.WriteFile(fs, config.ActiveDir()+"/abc", []byte("I am not even a kubeconfig, what am I doing here?"), utils.KonfPerm)
 	afero.WriteFile(fs, utils.ActivePathForID("1234"), []byte(sm.SingleClusterSingleContextEU()), utils.KonfPerm)
 	return fs
@@ -162,7 +163,7 @@ func mixedFSWithAllProcs(t *testing.T) (fs afero.Fs, cmdsRunning []*exec.Cmd, cm
 	numOfConfs := 3
 
 	fs = afero.NewMemMapFs()
-	sm := utils.SampleKonfManager{}
+	sm := testhelper.SampleKonfManager{}
 
 	for i := 1; i <= numOfConfs; i++ {
 		// set sleep to an extremely high number as the argument "infinity" does not exist in all versions of the util

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/simontheleg/konf-go/prompt"
-	"github.com/simontheleg/konf-go/utils"
+	"github.com/simontheleg/konf-go/testhelper"
 	"github.com/spf13/afero"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ func TestNamespace(t *testing.T) {
 			cmd := nscmd.cmd
 
 			err := cmd.RunE(cmd, tc.Args)
-			if !utils.EqualError(tc.ExpErr, err) {
+			if !testhelper.EqualError(tc.ExpErr, err) {
 				t.Errorf("Exp error %q, got %q", tc.ExpErr, err)
 			}
 
@@ -119,7 +119,7 @@ func TestSearchNamespace(t *testing.T) {
 }
 
 func TestNewKubeClientSet(t *testing.T) {
-	fm := utils.FilesystemManager{}
+	fm := testhelper.FilesystemManager{}
 
 	tt := map[string]struct {
 		kubeenv string
@@ -133,12 +133,12 @@ func TestNewKubeClientSet(t *testing.T) {
 		},
 		"valid kubeconfig": {
 			"./konf/active/dev-eu_dev-eu-1.yaml",
-			utils.FSWithFiles(fm.ActiveDir, fm.SingleClusterSingleContextEU),
+			testhelper.FSWithFiles(fm.ActiveDir, fm.SingleClusterSingleContextEU),
 			false,
 		},
 		"invalid kubeconfig": {
 			"./konf/active/no-konf.yaml",
-			utils.FSWithFiles(fm.ActiveDir, fm.InvalidYaml),
+			testhelper.FSWithFiles(fm.ActiveDir, fm.InvalidYaml),
 			true,
 		},
 	}
@@ -217,7 +217,7 @@ func TestSelectNamespace(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			res, err := selectNamespace(tc.csc, tc.sel, nil)
 
-			if !utils.EqualError(err, tc.expErr) {
+			if !testhelper.EqualError(err, tc.expErr) {
 				t.Errorf("Exp err %q, got %q", tc.expErr, err)
 			}
 
@@ -230,7 +230,7 @@ func TestSelectNamespace(t *testing.T) {
 }
 
 func TestSetNamespace(t *testing.T) {
-	fm := utils.FilesystemManager{}
+	fm := testhelper.FilesystemManager{}
 
 	tt := map[string]struct {
 		kubeenv string
@@ -246,19 +246,19 @@ func TestSetNamespace(t *testing.T) {
 		},
 		"valid kubeconfig": {
 			"./konf/active/dev-eu_dev-eu-1.yaml",
-			utils.FSWithFiles(fm.ActiveDir, fm.SingleClusterSingleContextEU),
+			testhelper.FSWithFiles(fm.ActiveDir, fm.SingleClusterSingleContextEU),
 			"kube-system",
 			false,
 		},
 		"invalid kubeconfig": {
 			"./konf/active/no-konf.yaml",
-			utils.FSWithFiles(fm.ActiveDir, fm.InvalidYaml),
+			testhelper.FSWithFiles(fm.ActiveDir, fm.InvalidYaml),
 			"kube-system",
 			true,
 		},
 		"valid kubeconfig, but missing context[]": {
 			"./konf/active/no-context.yaml",
-			utils.FSWithFiles(fm.ActiveDir, fm.KonfWithoutContext),
+			testhelper.FSWithFiles(fm.ActiveDir, fm.KonfWithoutContext),
 			"kube-system",
 			true,
 		},

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/simontheleg/konf-go/config"
 	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
+	"github.com/simontheleg/konf-go/testhelper"
 )
 
 func TestSelectLastKonf(t *testing.T) {
-	fm := utils.FilesystemManager{}
+	fm := testhelper.FilesystemManager{}
 
 	tt := map[string]struct {
 		InFs     afero.Fs
@@ -26,12 +27,12 @@ func TestSelectLastKonf(t *testing.T) {
 		ExpError error
 	}{
 		"latestKonf set": {
-			InFs:     utils.FSWithFiles(fm.LatestKonf),
+			InFs:     testhelper.FSWithFiles(fm.LatestKonf),
 			ExpID:    "context_cluster",
 			ExpError: nil,
 		},
 		"no latestKonf": {
-			InFs:     utils.FSWithFiles(),
+			InFs:     testhelper.FSWithFiles(),
 			ExpID:    "",
 			ExpError: fmt.Errorf("could not select latest konf, because no konf was yet set"),
 		},
@@ -41,7 +42,7 @@ func TestSelectLastKonf(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			id, err := selectLastKonf(tc.InFs)
 
-			if !utils.EqualError(tc.ExpError, err) {
+			if !testhelper.EqualError(tc.ExpError, err) {
 				t.Errorf("Want error %q, got %q", tc.ExpError, err)
 			}
 
@@ -77,7 +78,7 @@ func TestSaveLatestKonf(t *testing.T) {
 func TestSetContext(t *testing.T) {
 	storeDir := config.StoreDir()
 	ppid := os.Getppid()
-	sm := utils.SampleKonfManager{}
+	sm := testhelper.SampleKonfManager{}
 
 	tt := map[string]struct {
 		InID        string
@@ -232,7 +233,7 @@ func checkTemplate(t *testing.T, stpl string, val tableOutput, exp string) {
 }
 
 func TestFetchKonfs(t *testing.T) {
-	fm := utils.FilesystemManager{}
+	fm := testhelper.FilesystemManager{}
 
 	tt := map[string]struct {
 		FSIn        afero.Fs
@@ -240,12 +241,12 @@ func TestFetchKonfs(t *testing.T) {
 		ExpTableOut []tableOutput
 	}{
 		"empty store": {
-			FSIn:        utils.FSWithFiles(fm.StoreDir),
+			FSIn:        testhelper.FSWithFiles(fm.StoreDir),
 			CheckError:  expEmptyStore,
 			ExpTableOut: nil,
 		},
 		"valid konfs and a wrong konf": {
-			FSIn:       utils.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU, fm.SingleClusterSingleContextASIA, fm.InvalidYaml),
+			FSIn:       testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU, fm.SingleClusterSingleContextASIA, fm.InvalidYaml),
 			CheckError: expNil,
 			ExpTableOut: []tableOutput{
 				{
@@ -261,12 +262,12 @@ func TestFetchKonfs(t *testing.T) {
 			},
 		},
 		"overloaded konf (cluster)": {
-			FSIn:        utils.FSWithFiles(fm.StoreDir, fm.MultiClusterSingleContext),
+			FSIn:        testhelper.FSWithFiles(fm.StoreDir, fm.MultiClusterSingleContext),
 			CheckError:  expKubeConfigOverload,
 			ExpTableOut: nil,
 		},
 		"overloaded konf (context)": {
-			FSIn:        utils.FSWithFiles(fm.StoreDir, fm.SingleClusterMultiContext),
+			FSIn:        testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterMultiContext),
 			CheckError:  expKubeConfigOverload,
 			ExpTableOut: nil,
 		},
@@ -286,8 +287,8 @@ func TestFetchKonfs(t *testing.T) {
 }
 
 func TestSelectContext(t *testing.T) {
-	fm := utils.FilesystemManager{}
-	f := utils.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU, fm.SingleClusterSingleContextASIA)
+	fm := testhelper.FilesystemManager{}
+	f := testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU, fm.SingleClusterSingleContextASIA)
 
 	// cases
 	// - invalid selection
@@ -324,7 +325,7 @@ func TestSelectContext(t *testing.T) {
 
 			res, err := selectContext(f, tc.pf)
 
-			if !utils.EqualError(err, tc.expErr) {
+			if !testhelper.EqualError(err, tc.expErr) {
 				t.Errorf("Exp err %q, got %q", tc.expErr, err)
 			}
 

--- a/cmd/shellwrapper_test.go
+++ b/cmd/shellwrapper_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/simontheleg/konf-go/utils"
+	"github.com/simontheleg/konf-go/testhelper"
 )
 
 func TestShellWrapperCmd(t *testing.T) {
@@ -34,7 +34,7 @@ func TestShellWrapperCmd(t *testing.T) {
 
 			err := cmd.RunE(cmd, tc.args)
 
-			if !utils.EqualError(err, tc.ExpErr) {
+			if !testhelper.EqualError(err, tc.ExpErr) {
 				t.Errorf("Want error '%s', got '%s'", tc.ExpErr, err)
 			}
 		})

--- a/testhelper/unit.go
+++ b/testhelper/unit.go
@@ -1,11 +1,11 @@
-package utils
+package testhelper
 
 import (
 	"github.com/simontheleg/konf-go/config"
+	"github.com/simontheleg/konf-go/utils"
 	"github.com/spf13/afero"
 )
 
-const IntegrationtestDir = "/tmp/konfs"
 
 // EqualError reports whether errors a and b are considered equal.
 // They're equal if both are nil, or both are not nil and a.Error() == b.Error().
@@ -27,42 +27,42 @@ func FSWithFiles(ff ...filefunc) afero.Fs {
 type FilesystemManager struct{}
 
 func (*FilesystemManager) StoreDir(fs afero.Fs) {
-	fs.MkdirAll(config.StoreDir(), KonfPerm)
+	fs.MkdirAll(config.StoreDir(), utils.KonfPerm)
 }
 
 func (*FilesystemManager) ActiveDir(fs afero.Fs) {
-	fs.MkdirAll(config.ActiveDir(), KonfPerm)
+	fs.MkdirAll(config.ActiveDir(), utils.KonfPerm)
 }
 
 func (*FilesystemManager) SingleClusterSingleContextEU(fs afero.Fs) {
-	afero.WriteFile(fs, StorePathForID("dev-eu_dev-eu-1"), []byte(singleClusterSingleContextEU), KonfPerm)
-	afero.WriteFile(fs, ActivePathForID("dev-eu_dev-eu-1"), []byte(singleClusterSingleContextEU), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("dev-eu_dev-eu-1"), []byte(singleClusterSingleContextEU), utils.KonfPerm)
+	afero.WriteFile(fs, utils.ActivePathForID("dev-eu_dev-eu-1"), []byte(singleClusterSingleContextEU), utils.KonfPerm)
 }
 
 func (*FilesystemManager) SingleClusterSingleContextASIA(fs afero.Fs) {
-	afero.WriteFile(fs, StorePathForID("dev-asia_dev-asia-1"), []byte(singleClusterSingleContextASIA), KonfPerm)
-	afero.WriteFile(fs, ActivePathForID("dev-asia_dev-asia-1"), []byte(singleClusterSingleContextASIA), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("dev-asia_dev-asia-1"), []byte(singleClusterSingleContextASIA), utils.KonfPerm)
+	afero.WriteFile(fs, utils.ActivePathForID("dev-asia_dev-asia-1"), []byte(singleClusterSingleContextASIA), utils.KonfPerm)
 }
 
 func (*FilesystemManager) InvalidYaml(fs afero.Fs) {
-	afero.WriteFile(fs, ActivePathForID("no-konf"), []byte("I am no valid yaml"), KonfPerm)
-	afero.WriteFile(fs, StorePathForID("no-konf"), []byte("I am no valid yaml"), KonfPerm)
+	afero.WriteFile(fs, utils.ActivePathForID("no-konf"), []byte("I am no valid yaml"), utils.KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("no-konf"), []byte("I am no valid yaml"), utils.KonfPerm)
 }
 
 func (*FilesystemManager) MultiClusterMultiContext(fs afero.Fs) {
-	afero.WriteFile(fs, StorePathForID("multi_multi_konf"), []byte(multiClusterMultiContext), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("multi_multi_konf"), []byte(multiClusterMultiContext), utils.KonfPerm)
 }
 
 func (*FilesystemManager) MultiClusterSingleContext(fs afero.Fs) {
-	afero.WriteFile(fs, StorePathForID("multi_konf"), []byte(multiClusterSingleContext), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("multi_konf"), []byte(multiClusterSingleContext), utils.KonfPerm)
 }
 
 func (*FilesystemManager) SingleClusterMultiContext(fs afero.Fs) {
-	afero.WriteFile(fs, StorePathForID("multi_konf"), []byte(singleClusterMultiContext), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("multi_konf"), []byte(singleClusterMultiContext), utils.KonfPerm)
 }
 
 func (*FilesystemManager) LatestKonf(fs afero.Fs) {
-	afero.WriteFile(fs, config.LatestKonfFile(), []byte("context_cluster"), KonfPerm)
+	afero.WriteFile(fs, config.LatestKonfFile(), []byte("context_cluster"), utils.KonfPerm)
 }
 
 func (*FilesystemManager) KonfWithoutContext(fs afero.Fs) {
@@ -79,8 +79,8 @@ users:
     user: {}
 `
 
-	afero.WriteFile(fs, StorePathForID("no-context"), []byte(noContext), KonfPerm)
-	afero.WriteFile(fs, ActivePathForID("no-context"), []byte(noContext), KonfPerm)
+	afero.WriteFile(fs, utils.StorePathForID("no-context"), []byte(noContext), utils.KonfPerm)
+	afero.WriteFile(fs, utils.ActivePathForID("no-context"), []byte(noContext), utils.KonfPerm)
 }
 
 type SampleKonfManager struct{}

--- a/utils/dir.go
+++ b/utils/dir.go
@@ -10,6 +10,8 @@ import (
 const KonfPerm fs.FileMode = 0600    // based on the standard file-permissions for .kube/config
 const KonfDirPerm fs.FileMode = 0700 // needed so we can create folders inside
 
+const IntegrationtestDir = "/tmp/konfs"
+
 // EnsureDir makes sure that konf store and active dirs exist
 func EnsureDir(f afero.Fs) error {
 

--- a/utils/id_test.go
+++ b/utils/id_test.go
@@ -93,7 +93,6 @@ func TestIDFileValidityIntegration(t *testing.T) {
 		t.Skip("Skipping TestIDFileValidityIntegration integration test")
 	}
 
-	sm := SampleKonfManager{}
 	f := afero.NewOsFs()
 	dir := IntegrationtestDir + "/TestIDFileValidityIntegration"
 
@@ -115,7 +114,8 @@ func TestIDFileValidityIntegration(t *testing.T) {
 		id := IDFromClusterAndContext(co.cluster, co.context)
 		fpath := fmt.Sprintf("%s/%s.yaml", dir, id)
 
-		err := afero.WriteFile(f, fpath, []byte(sm.SingleClusterSingleContextEU()), KonfPerm)
+		// it should be fine to write empty
+		err := afero.WriteFile(f, fpath, []byte{}, KonfPerm)
 		if err != nil {
 			t.Errorf("Exp filename %q to work, but got error %q", fpath, err)
 		}


### PR DESCRIPTION
This makes sense as the package utils is used by our commands and
therefore should have a high test-coverage. The opposite is true for the
mock-filesystems we use, which now are extracted into their own,
untested package