### PR TITLE
add tab completion for zsh

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,3 +36,20 @@ jobs:
       # the unittests for windows in ./cmd (even if there is no integration test there) and fail
       # in the build phase already with 'unknown field 'Setpgid' in struct literal of type syscall.SysProcAttr'
       - run: go test -run Integration ./utils
+  shellwrapper-test:
+    runs-on: ubuntu-latest
+    name: shellwrapper
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.6 # for now we can keep this as a fixed version
+      - name: Install zsh # until https://github.com/actions/virtual-environments/issues/4849 is resolved
+        run: sudo apt-get update; sudo apt-get install zsh
+      - name: Install konf-go
+        run: go install .
+      - name: zsh test
+        run: zsh testhelper/shellwrapper.sh
+      - name: bash test
+        run: bash testhelper/shellwrapper.sh

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
   - [How does it work?](#how-does-it-work)
     - [kubeconfig management across shells](#kubeconfig-management-across-shells)
     - [zsh/bash-func-magic](#zshbash-func-magic)
+    - [Upgrading spf13/cobra](#upgrading-spf13cobra)
   - [Contributing](#contributing)
     - [Usage of stdout and stderr](#usage-of-stdout-and-stderr)
     - [Tests](#tests)
@@ -41,7 +42,9 @@ source <(konf-go shellwrapper zsh)
 alias kctx="konf set"
 alias kns="konf ns"
 # Open last konf on new session (use --silent to suppress INFO log line)
-export KUBECONFIG=$(konf-go --silent set -)
+export KUBECONFIG=$(konf --silent set -)
+# Autocompletion. Currently supported shells: zsh
+source <(konf completion zsh)
 ```
 
 ## Usage
@@ -85,6 +88,13 @@ Essentially a child process cannot make modifications to its parents.
 This includes setting an environment variable, which affects us because we want to set `$KUBECONFIG`.
 The way we work around this "limitation" is by using a zsh/bash function that executes our binary and then sets `$KUBECONFIG` to the output of `konf-go`.
 With this trick we are able to set `$KUBECONFIG` and can make this project work. Since only the result of stdout will be captured by the zsh/bash-func, we can still communicate normally with the user by using stderr.
+
+### Upgrading spf13/cobra
+
+Special care should be taken before upgrading the cobra package.
+This is due to the fact that in `completion.go` we use the standard completion from the library and then apply some string insertions at certain positions.
+As a result, before any upgrade of the package, it should be checked whether the GenXYZCompletion funcs from cobra have changed.
+Unfortunately I was not able to find a more elegant solution, so for now we just have to be vigilant when upgrading the dependency.
 
 ## Contributing
 

--- a/Readme.md
+++ b/Readme.md
@@ -90,11 +90,10 @@ With this trick we are able to set `$KUBECONFIG` and can make this project work.
 
 ### Usage of stdout and stderr
 
-When developing for konf, it is important to keep in mind that you can never print anything to stdout. You always have to use stderr. This is because anything printed to stdout will automatically be added to the `$KUBECONFIG` variable by the surrounding zsh-func. This has the following implications
-
-- Since cobra only makes the out for commands accesible via the `SetOut()` accessor, all future commands for konf should be implemented by wrapping cobra.Command and creating a custom creation func.
-An example can be found in the `shellwrapper.go` command. Other commands will be refactored over time, and should not be taken as role-models.
-- promptUI always needs to be configured to use stderr, otherwise no prompt will appear
+When developing for konf, it is important to understand the konf-shellwrapper. It is designed to solve the problem described in the [zsh/bash-func-magic section](###zsh/bash-func-magic).
+It works by saving the stdOut of konf-go in a separate variable and then evaluating the result. Should the result contain the keyword `KUBECONFIGCHANGE:`, the wrapper will set `$KUBECONFIG` to the value after the colon.
+Otherwise the wrapper ist just going to print the result to stdOut in the terminal. This setup allows for konf-go commands to print to stdOut (which is required for example for zsh/bash completion). Additionally it should be able to handle large stdOut outputs as well, as it only parses the first line of output.
+Interactive prompts however (like promptUI) should always print their dialogue to stdErr, as the wrapper has troubles with user input. Nonetheless you can still easily submit the result of the selection to the wrapper later on using the aforementioned keyword. So it should not be a big issue.
 
 ### Tests
 

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -98,6 +98,5 @@ func cleanLeftOvers(f afero.Fs) error {
 }
 
 func init() {
-	cleanupCmd.SetOut(os.Stderr)
 	rootCmd.AddCommand(cleanupCmd)
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Main modifications from the auto-generated completion.go by cobra are to accommodate the konf wrapper.
+// A detailed explanation can be found on a per shell basis down below
+// The preset for this file is taken from https://github.com/spf13/cobra/blob/master/shell_completions.md
+
+type completionCmd struct {
+	cmd *cobra.Command
+}
+
+func newCompletionCmd() *completionCmd {
+	cc := completionCmd{}
+
+	cc.cmd = &cobra.Command{
+		Use:   "completion [bash|zsh]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+  # To load completions for each session, add this to your zshrc:
+
+  source <(konf completion bash)
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. Simply add the following to your .zshrc:
+
+  autoload -U compinit && compinit
+
+  # To load completions for each session, add this to your zshrc:
+	source <(konf completion zsh)
+
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh"},
+		Args:                  cobra.ExactValidArgs(1),
+		RunE:                  cc.completion,
+	}
+
+	return &cc
+}
+
+func (c *completionCmd) completion(cmd *cobra.Command, args []string) error {
+	switch args[0] {
+
+	case "zsh":
+		// This allows for also using 'source <(konf completion zsh)' with zsh, similar to bash.
+		// Basically it just adds the compdef command so it can be run. Taken from kubectl, who
+		// do a similar thing
+		zshHeader := "#compdef _konf konf\ncompdef _konf konf\n"
+
+		// So per default cobra makes use of the words[] array that zsh provides to you in completion funcs.
+		// Words is an array that contains all words that have been typed by the user before hitting tab
+		// Now cobra takes words[1] which is equal to the name of the comand and uses this to call completion on it
+		// However in our case this does not work as words[1] points to 'konf' which is the wrapper and not the binary
+		// In order to solve this we have to ensure that words[1] equates to konf-go, which is the binary.
+		// Currently I have found, the fastest way to do this is by inserting a line to overwrite words[1]. This is
+		// because the words[1] reference is used throughout the script and I would not want to replace all of it
+		var b bytes.Buffer
+		err := rootCmd.GenZshCompletion(&b)
+		if err != nil {
+			return err
+		}
+		anchor := "local -a completions" // this is basically a line early in the original script that we are going to cling onto
+		genZsh := strings.Replace(b.String(), anchor, anchor+"\n    words[1]=\"konf-go\"", 1)
+
+		os.Stdout.WriteString(zshHeader + genZsh)
+
+	default:
+		return fmt.Errorf("konf currently does not support autocompletions for %s", args[0])
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(newCompletionCmd().cmd)
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/simontheleg/konf-go/testhelper"
+)
+
+func TestCompletionCmd(t *testing.T) {
+
+	tt := map[string]struct {
+		args   []string
+		ExpErr error
+	}{
+		"zsh arg": {
+			[]string{"zsh"},
+			nil,
+		},
+		"invalid bash arg": {
+			[]string{"bash"},
+			fmt.Errorf("konf currently does not support autocompletions for bash"),
+		},
+		"invalid arg": {
+			[]string{"fish"},
+			fmt.Errorf("konf currently does not support autocompletions for fish"),
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			cc := newCompletionCmd()
+			cmd := cc.cmd
+
+			err := cmd.RunE(cmd, tc.args)
+
+			if !testhelper.EqualError(err, tc.ExpErr) {
+				t.Errorf("Want error '%s', got '%s'", tc.ExpErr, err)
+			}
+		})
+	}
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/simontheleg/konf-go/log"
 	"github.com/simontheleg/konf-go/utils"
@@ -45,8 +44,6 @@ contain a single context. Import will take care of splitting if necessary.`,
 		Args: cobra.ExactArgs(1),
 		RunE: ic.importf,
 	}
-
-	ic.cmd.SetOut(os.Stderr)
 
 	return ic
 }

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -58,8 +58,6 @@ Examples:
 		Args: cobra.MaximumNArgs(1),
 	}
 
-	cc.cmd.SetOut(os.Stderr)
-
 	return cc
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"io"
-	"os"
 
 	"github.com/simontheleg/konf-go/config"
 	"github.com/simontheleg/konf-go/log"
@@ -31,7 +30,6 @@ Afterwards switch between different kubeconfigs via 'konf set'
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.SetOut(os.Stderr)
 	cobra.CheckErr(rootCmd.Execute())
 }
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -66,7 +66,7 @@ Examples:
 		// By printing out to stdout, we pass the value to our zsh hook, which then sets $KUBECONFIG to it
 		// Both operate on the convention to use "KUBECONFIGCHANGE:<new-path>". If you change this part in
 		// here, do not forget to update shellwraper.go
-		fmt.Println("KUBECONFIGCHANGE:"+context)
+		fmt.Println("KUBECONFIGCHANGE:" + context)
 
 		return nil
 	},
@@ -272,6 +272,5 @@ func prepareTable(maxColumnLen int) (inactive, active, label string) {
 }
 
 func init() {
-	setCmd.SetOut(os.Stderr)
 	rootCmd.AddCommand(setCmd)
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -62,8 +62,11 @@ Examples:
 		}
 
 		log.Info("Setting context to %q\n", id)
+
 		// By printing out to stdout, we pass the value to our zsh hook, which then sets $KUBECONFIG to it
-		fmt.Println(context)
+		// Both operate on the convention to use "KUBECONFIGCHANGE:<new-path>". If you change this part in
+		// here, do not forget to update shellwraper.go
+		fmt.Println("KUBECONFIGCHANGE:"+context)
 
 		return nil
 	},

--- a/cmd/shellwrapper.go
+++ b/cmd/shellwrapper.go
@@ -37,11 +37,11 @@ func (c *shellwrapperCmd) shellwrapper(cmd *cobra.Command, args []string) error 
 	var zsh = `
 konf() {
   res=$(konf-go $@)
-  # protect against an empty command
-  # Note we cannot do something like if "$1 == set" and only run the export on set commands as cmd flags can be at any position in our cli
-  if [[ $res != "" ]]
+  # only change $KUBECONFIG if instructed by konf-go
+  if [[ $res == "KUBECONFIGCHANGE:"* ]]
 	then
-    export KUBECONFIG=$res
+    # this basically takes the line and cuts out the KUBECONFIGCHANGE Part
+    export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
   fi
 }
 konf_cleanup() {
@@ -53,11 +53,11 @@ add-zsh-hook zshexit konf_cleanup
 	var bash = `
 konf() {
   res=$(konf-go $@)
-  # protect against an empty command
-  # Note we cannot do something like if "$1 == set" and only run the export on set commands as cmd flags can be at any position in our cli
-  if [[ $res != "" ]]
+  # only change $KUBECONFIG if instructed by konf-go
+  if [[ $res == "KUBECONFIGCHANGE:"* ]]
 	then
-    export KUBECONFIG=$res
+    # this basically takes the line and cuts out the KUBECONFIGCHANGE Part
+    export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
   fi
 }
 konf_cleanup() {

--- a/cmd/shellwrapper.go
+++ b/cmd/shellwrapper.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -27,8 +26,6 @@ See https://github.com/SimonTheLeg/konf-go#installation on how to do so
 		Args: cobra.ExactArgs(1),
 	}
 
-	sc.cmd.SetOut(os.Stderr)
-
 	return &sc
 }
 
@@ -39,9 +36,12 @@ konf() {
   res=$(konf-go $@)
   # only change $KUBECONFIG if instructed by konf-go
   if [[ $res == "KUBECONFIGCHANGE:"* ]]
-	then
+  then
     # this basically takes the line and cuts out the KUBECONFIGCHANGE Part
     export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
+  else
+    # this makes --help work
+    echo $res
   fi
 }
 konf_cleanup() {
@@ -55,9 +55,12 @@ konf() {
   res=$(konf-go $@)
   # only change $KUBECONFIG if instructed by konf-go
   if [[ $res == "KUBECONFIGCHANGE:"* ]]
-	then
+  then
     # this basically takes the line and cuts out the KUBECONFIGCHANGE Part
     export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
+  else
+    # this makes --help work
+    echo $res
   fi
 }
 konf_cleanup() {

--- a/testhelper/shellwrapper.sh
+++ b/testhelper/shellwrapper.sh
@@ -1,0 +1,35 @@
+# This script tests the compatibility of the konf-go shellwrappe with different shells
+# Therefore it has no shebang line and is intended to be executed directly by the shell to test
+
+set -o errexit
+set -o pipefail
+
+
+if [[ -n ${ZSH_VERSION} ]]
+then
+  shell="zsh"
+  autoload -U add-zsh-hook # this is required so the shellwrapper can be sourced
+elif [[ -n ${BASH_VERSION} ]]
+then
+  shell="bash"
+else
+  echo "no valid shell detected"
+  exit 1
+fi
+
+echo "${shell} detected. Running tests using ${shell} wrapper"
+
+source <(konf-go shellwrapper ${shell})
+
+KONFDIR=$(mktemp -d)
+mkdir ${KONFDIR}/store
+KONF=${KONFDIR}/store/test_test.yaml
+touch ${KONF}
+konf --konf-dir=${KONFDIR} set test_test
+
+# if kubeconfig points to something in the active
+if [[ $KUBECONFIG != "${KONFDIR}/active"* ]]; then
+  echo "Expected KUBECONFIG to point to a file inside '${KONFDIR}/active', but got '${KUBECONFIG}'"
+fi
+
+echo "KUBECONFIG points to '${KUBECONFIG}', which looks fine"


### PR DESCRIPTION
This PR includes adding the completion framework to konf for zsh. 

To make this work, this PR has some magnificent changes under the hood 🌟 :
- create more flexible konf-wrapper, so commands can now use stdIn and not have to use stdErr for everything
- create an integration test to test the konf-wrapper against different shells

It is not a breaking change, but it is recommended for alpha users to update their .zshrc with the settings recommended in the new Readme