### PR TITLE
fix: go mod dependencies for fuzzysearch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,9 @@
 - [Konf - Lightweight kubeconfig Manager](#konf---lightweight-kubeconfig-manager)
   - [Why konf?](#why-konf)
   - [Installation](#installation)
+    - [1. Install the konf-go binary](#1-install-the-konf-go-binary)
+    - [2. Install the konf shellwrapper](#2-install-the-konf-shellwrapper)
+    - [Customizations to Have a Good Time](#customizations-to-have-a-good-time)
   - [Usage](#usage)
   - [How does it work?](#how-does-it-work)
     - [kubeconfig management across shells](#kubeconfig-management-across-shells)
@@ -23,28 +26,40 @@
 
 ## Installation
 
-Run
+### 1. Install the konf-go binary
 
 ```shell
 go install github.com/simontheleg/konf-go@latest
 ```
 
-Afterwards, add the following to your `.zshrc` / `.bashrc` and restart your shell or re-source this file:
+This will install a binary called konf-go into your PATH.
+Please do not rename or alias this binary, it is not be called by the user directly. Instead alias the konf shellwrapper described in the next step!
 
-```zsh
-# mandatory konf settings. This will install a shell wrapper called "konf" for you to use.
-# Always use this wrapper, never call the konf-go binary directly!
+### 2. Install the konf shellwrapper
+
+Add the following to your `.zshrc` / `.bashrc` and restart your shell or re-source this file:
+
+```sh
 # Currently supported shells: zsh, bash
 source <(konf-go shellwrapper zsh)
+```
 
-# optional konf settings
+This will install a shellwrapper called `konf`, which you can use like any command. The wrapper can also be aliased if need be.
+
+### Customizations to Have a Good Time
+
+A collection of optional settings to improve quality of life with konf. These can be added to your `.zshrc` / `.bashrc`:
+
+```sh
+# Autocompletion. Currently supported shells: zsh, bash
+source <(konf completion zsh)
+
+# Open last konf on new shell session
+export KUBECONFIG=$(konf --silent set -)
+
 # Alias
 alias kctx="konf set"
 alias kns="konf ns"
-# Open last konf on new session (use --silent to suppress INFO log line)
-export KUBECONFIG=$(konf --silent set -)
-# Autocompletion. Currently supported shells: zsh
-source <(konf completion zsh)
 ```
 
 ## Usage

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -77,6 +77,17 @@ func (c *completionCmd) completion(cmd *cobra.Command, args []string) error {
 
 		os.Stdout.WriteString(zshHeader + genZsh)
 
+	case "bash":
+		var b bytes.Buffer
+		err := rootCmd.GenBashCompletionV2(&b, true)
+		if err != nil {
+			return err
+		}
+		anchor := "local requestComp lastParam lastChar args"
+		genBash := strings.Replace(b.String(), anchor, anchor+"\n    words[0]=\"konf-go\"", 1) // basically the same as for zsh, but this words[] is zero-indexed
+
+		os.Stdout.WriteString(genBash)
+
 	default:
 		return fmt.Errorf("konf currently does not support autocompletions for %s", args[0])
 	}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -17,9 +17,9 @@ func TestCompletionCmd(t *testing.T) {
 			[]string{"zsh"},
 			nil,
 		},
-		"invalid bash arg": {
+		"bash arg": {
 			[]string{"bash"},
-			fmt.Errorf("konf currently does not support autocompletions for bash"),
+			nil,
 		},
 		"invalid arg": {
 			[]string{"fish"},

--- a/cmd/shellwrapper.go
+++ b/cmd/shellwrapper.go
@@ -41,7 +41,7 @@ konf() {
     export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
   else
     # this makes --help work
-    echo $res
+    echo "${res}"
   fi
 }
 konf_cleanup() {
@@ -60,7 +60,7 @@ konf() {
     export KUBECONFIG="${res#*KUBECONFIGCHANGE:}"
   else
     # this makes --help work
-    echo $res
+    echo "${res}"
   fi
 }
 konf_cleanup() {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-cmp v0.5.5
+	github.com/lithammer/fuzzysearch v1.1.3
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/spf13/afero v1.6.0
@@ -31,7 +32,6 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
-	github.com/lithammer/fuzzysearch v1.1.3 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -511,7 +511,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=


### PR DESCRIPTION
This PR adds the basic tab completion for bash.

Additionally under the hood, it fixes and issue that bash shells had with multiline output from the wrapper.