### PR TITLE
fix: handling of hidden files

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -197,6 +197,17 @@ func fetchKonfs(f afero.Fs) ([]tableOutput, error) {
 
 	out := []tableOutput{}
 	for _, konf := range konfs {
+
+		// ignore any hidden files
+		if strings.HasPrefix(konf.Name(), ".") {
+			// I have decided to not print any log line on this, which differs from the logic
+			// for malformed kubeconfigs. I think this makese sense as konf import will never produce
+			// a hidden file and the purpose of this is check is rather to protect against
+			// automatically created files like the .DS_Store on MacOs. On the other side however
+			// it is quite easy to create a malformed kubeconfig without noticing
+			continue
+		}
+
 		id := utils.IDFromFileInfo(konf)
 		path := utils.StorePathForID(id)
 		file, err := f.Open(path)

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -312,6 +312,17 @@ func TestFetchKonfs(t *testing.T) {
 			CheckError:  expKubeConfigOverload,
 			ExpTableOut: nil,
 		},
+		"the nice MacOS .DS_Store file": {
+			FSIn:       testhelper.FSWithFiles(fm.StoreDir, fm.DSStore, fm.SingleClusterSingleContextEU),
+			CheckError: expNil,
+			ExpTableOut: []tableOutput{
+				{
+					Context: "dev-eu",
+					Cluster: "dev-eu-1",
+					File:    "./konf/store/dev-eu_dev-eu-1.yaml",
+				},
+			},
+		},
 	}
 
 	for name, tc := range tt {

--- a/testhelper/unit.go
+++ b/testhelper/unit.go
@@ -97,6 +97,13 @@ users:
 	afero.WriteFile(fs, utils.ActivePathForID("no-context"), []byte(noContext), utils.KonfPerm)
 }
 
+// DSStore creates a .DS_Store file, that has caused quite some problems in the past
+func (*FilesystemManager) DSStore(fs afero.Fs) {
+	// in this case we cannot use StorePathForID, as this would append .yaml
+	afero.WriteFile(fs, config.StoreDir()+"/.DS_Store", nil, utils.KonfPerm)
+	afero.WriteFile(fs, config.ActiveDir()+"/.DS_Store", nil, utils.KonfPerm)
+}
+
 // SampleKonfManager is used to manage kubeconfig strings. It is feature identical to
 // its file counterpart FilesystemManager
 type SampleKonfManager struct{}


### PR DESCRIPTION
This commit improves the handling of hidden files in the store. Usually it should be impossible for konf import to create such hidden files. However operating systems like MacOs, may place hidden files in the
folder on their own. Before this fix, files like .DS_Store were breaking all
konf set functionality