### PR TITLE
fix: storeDir with only dirs

### DIFF
--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -323,6 +323,22 @@ func TestFetchKonfs(t *testing.T) {
 				},
 			},
 		},
+		"ignore directories": {
+			FSIn:       testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU, fm.EmptyDir),
+			CheckError: expNil,
+			ExpTableOut: []tableOutput{
+				{
+					Context: "dev-eu",
+					Cluster: "dev-eu-1",
+					File:    "./konf/store/dev-eu_dev-eu-1.yaml",
+				},
+			},
+		},
+		"only directories in store": {
+			FSIn:        testhelper.FSWithFiles(fm.StoreDir, fm.EmptyDir),
+			CheckError:  expEmptyStore,
+			ExpTableOut: nil,
+		},
 	}
 
 	for name, tc := range tt {

--- a/testhelper/unit.go
+++ b/testhelper/unit.go
@@ -104,6 +104,13 @@ func (*FilesystemManager) DSStore(fs afero.Fs) {
 	afero.WriteFile(fs, config.ActiveDir()+"/.DS_Store", nil, utils.KonfPerm)
 }
 
+// DSStore creates an EmptyDir in StoreDir and ActiveDir
+func (*FilesystemManager) EmptyDir(fs afero.Fs) {
+	// in this case we cannot use StorePathForID, as this would append .yaml
+	fs.Mkdir(config.StoreDir()+"empty-dir", utils.KonfDirPerm)
+	fs.Mkdir(config.ActiveDir()+"empty-dir", utils.KonfDirPerm)
+}
+
 // SampleKonfManager is used to manage kubeconfig strings. It is feature identical to
 // its file counterpart FilesystemManager
 type SampleKonfManager struct{}


### PR DESCRIPTION
Fixes an issue where if you only had Dirs inside your storeDir, you
would see an empty prompt instead of the EmptyStoreDir warning