### PR TITLE
use deploy key in tagging workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,11 +13,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - name: bump semVer
-        uses: simontheleg/semver-tag-from-pr-action@v1.1.0
+          ssh-key: ${{ secrets.SEMVER_TAG_SSH_KEY }}
+      - name: tag
+        uses: simontheleg/semver-tag-from-pr-action@v1.4.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          label-major: merge-breaking
-          label-minor: merge-feature
-          label-patch: merge-fix
-          label-none: merge-none
+          # due to https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/8
+          # we have to actually use a deploy-key here, so that the release flows push.tags section is working
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          label_major: merge-breaking
+          label_minor: merge-feature
+          label_patch: merge-fix
+          label_none: merge-none
+          repo_ssh_key: ${{ secrets.SEMVER_TAG_SSH_KEY}}


### PR DESCRIPTION
This is required so the tag workflow can automatically trigger the
release workflow.