### PR TITLE
document Nix-based installation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,34 @@
 
 ### 1. Install the konf-go binary
 
-Either grab a pre-compiled binary from [GH Releases](https://github.com/SimonTheLeg/konf-go/releases) page, or build it from source using:
+#### 1.1 Pre-compiled binary Install the konf-go binary
+
+The [GH Releases](https://github.com/SimonTheLeg/konf-go/releases) provide pre-compiled binaries for common platforms.
+
+#### 1.2 Nix Package
+
+The package can be installed in the local nix-profile.
+
+```shell
+nix-env -iA nixpkgs.konf
+```
+
+For adhoc or testing purposes a shell with the package can be spawned.
+
+```
+nix-shell -p konf
+```
+
+For NixOS users it is highly recommended to install the package by adding it to the list of `systemPackages`.
+
+```nix
+environment.systemPackages = with pkgs; [
+  konf
+  # ...
+];
+```
+
+#### 1.3 Building from source
 
 ```shell
 go install github.com/simontheleg/konf-go@latest

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@
 
 ### 1. Install the konf-go binary
 
-#### 1.1 Pre-compiled binary Install the konf-go binary
+#### 1.1 Pre-compiled binary
 
 The [GH Releases](https://github.com/SimonTheLeg/konf-go/releases) provide pre-compiled binaries for common platforms.
 


### PR DESCRIPTION
Since this year's Kubernetes Community Days in Berlin, where I was introduced to this tool, I have been using `konf` almost every day and would like to thank you for it!

Now that versioning and a release cycle are provided, the packaging of the application in Nix is straightforward.
I took this as an opportunity to [create a Nix package](https://github.com/NixOS/nixpkgs/pull/190760) so that Nix-based systems can install the software more easily and elegantly.

In this pull request, I have a suggestion for the documentation of the Nix-based installation.