### PR TITLE
feat: add --move flag to import cmd

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -17,34 +19,47 @@ func TestImport(t *testing.T) {
 	fm := testhelper.FilesystemManager{}
 	var determineConfigsCalled bool
 	var writeConfigCalledCount int
+	var deleteOriginalConfigCalled bool
 	// using just a wrapper here instead of a full mock, makes testing it slightly easier
 	var wrapDetermineConfig = func(f afero.Fs, fpath string) ([]*konfFile, error) {
 		determineConfigsCalled = true
 		return determineConfigs(f, fpath)
 	}
 	var mockWriteConfig = func(afero.Fs, *konfFile) error { writeConfigCalledCount++; return nil }
+	var mockDeleteOriginalConfig = func(afero.Fs, string) error { deleteOriginalConfigCalled = true; return nil }
 
 	type ExpCalls struct {
-		DetermineConfigs bool
-		WriteConfig      int
+		DetermineConfigs     bool
+		WriteConfig          int
+		DeleteOriginalConfig bool
 	}
 	tt := map[string]struct {
 		Args      []string
 		FsCreator func() afero.Fs
 		ExpErr    error
+		MoveFlag  bool
 		ExpCalls
 	}{
 		"single context": {
 			[]string{"./konf/store/dev-eu_dev-eu-1.yaml"},
 			testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU),
 			nil,
+			false,
 			ExpCalls{DetermineConfigs: true, WriteConfig: 1},
 		},
 		"empty context": {
 			[]string{"./konf/store/no-context.yaml"},
 			testhelper.FSWithFiles(fm.StoreDir, fm.KonfWithoutContext),
 			fmt.Errorf("no contexts found in file \"./konf/store/no-context.yaml\""),
+			false,
 			ExpCalls{DetermineConfigs: true, WriteConfig: 0},
+		},
+		"move flag provided": {
+			[]string{"./konf/store/dev-eu_dev-eu-1.yaml"},
+			testhelper.FSWithFiles(fm.StoreDir, fm.SingleClusterSingleContextEU),
+			nil,
+			true,
+			ExpCalls{DetermineConfigs: true, WriteConfig: 1, DeleteOriginalConfig: true},
 		},
 	}
 
@@ -52,12 +67,15 @@ func TestImport(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			determineConfigsCalled = false
 			writeConfigCalledCount = 0
+			deleteOriginalConfigCalled = false
 			fs := tc.FsCreator()
 
 			icmd := newImportCmd()
 			icmd.fs = fs
 			icmd.determineConfigs = wrapDetermineConfig
 			icmd.writeConfig = mockWriteConfig
+			icmd.deleteOriginalConfig = mockDeleteOriginalConfig
+			icmd.move = tc.MoveFlag
 			cmd := icmd.cmd
 
 			// TODO unfortunately I was not able to use ExecuteC here as this would run
@@ -74,6 +92,10 @@ func TestImport(t *testing.T) {
 
 			if tc.ExpCalls.WriteConfig != writeConfigCalledCount {
 				t.Errorf("Exp WriteConfigCalled to be %d, but got %d", tc.ExpCalls.WriteConfig, writeConfigCalledCount)
+			}
+
+			if tc.ExpCalls.DeleteOriginalConfig != deleteOriginalConfigCalled {
+				t.Errorf("Exp DeleteOriginalConfigCalled to be %t, but got %t", tc.ExpCalls.DeleteOriginalConfig, deleteOriginalConfigCalled)
 			}
 
 		})
@@ -273,4 +295,19 @@ users:
 		t.Errorf("Exp to create clientset, but got %q", err)
 	}
 
+}
+
+func TestDeleteOriginalConfig(t *testing.T) {
+	fpath := "/dir/original-file.yaml"
+
+	f := afero.NewMemMapFs()
+	afero.WriteFile(f, fpath, nil, 0664)
+
+	if err := deleteOriginalConfig(f, fpath); err != nil {
+		t.Fatalf("Could not delete original kubeconfig %q: '%v'", fpath, err)
+	}
+
+	if _, err := f.Stat(fpath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Expected error to be FileNotFound, but got %v", err)
+	}
 }


### PR DESCRIPTION
the `--move` or `-m` flag allows for the deletion of the original kubeconfig upon successful import