### PR TITLE
feat: add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,3 +11,5 @@ builds:
       - ppc64le
       - s390x
     goarm: [6, 7]
+    ldflags:
+      - -s -w -X github.com/simontheleg/konf-go/cmd.gitversion={{.Version}} -X github.com/simontheleg/konf-go/cmd.gitcommit={{.Commit}} -X github.com/simontheleg/konf-go/cmd.builddate={{.Date}}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+type versionInfo struct {
+	GitVersion string
+	GitCommit  string
+	BuildDate  string
+	GoVersion  string
+	Platform   string
+	Compiler   string
+}
+
+// defaultVersion will be returned if no ldflags were provided e.g. when running
+// go build
+var defaultVersionInfo versionInfo = versionInfo{
+	GitVersion: "dev",
+	GitCommit:  "dev",
+	BuildDate:  "1970-01-01T00:00:00Z",
+	GoVersion:  runtime.Version(),
+	Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	Compiler:   runtime.Compiler,
+}
+
+type versionCmd struct {
+	cmd *cobra.Command
+}
+
+func newVersionCommand() *versionCmd {
+	vc := &versionCmd{}
+	vc.cmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print version info",
+		Long:  "Print version and build info in a json format",
+		RunE:  vc.version,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	return vc
+}
+
+func (c *versionCmd) version(cmd *cobra.Command, args []string) error {
+	fmt.Println(versionStringWithOverrides(gitversion, gitcommit, builddate))
+	return nil
+}
+
+// variables to be overridden by ldflags
+var (
+	gitversion string
+	gitcommit  string
+	builddate  string
+)
+
+// versionWithLDFlags takes in the overrides and returns a json compatible
+// version string
+func versionStringWithOverrides(gitversion string, gitcommit string, builddate string) string {
+	v := defaultVersionInfo
+	if gitversion != "" {
+		v.GitVersion = gitversion
+	}
+	if gitcommit != "" {
+		v.GitCommit = gitcommit
+	}
+	if builddate != "" {
+		v.BuildDate = builddate
+	}
+	return fmt.Sprintf(`{"GitVersion":"%s","GitCommit":"%s","BuildDate":"%s","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, v.GitVersion, v.GitCommit, v.BuildDate, v.GoVersion, v.Platform, v.Compiler)
+}
+
+func init() {
+	rootCmd.AddCommand(newVersionCommand().cmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestVersionStringWithOverrides(t *testing.T) {
+	tt := map[string]struct {
+		gitversion string
+		gitcommit  string
+		builddate  string
+		exp        string
+	}{
+		"no overrides": {
+			exp: fmt.Sprintf(`{"GitVersion":"dev","GitCommit":"dev","BuildDate":"1970-01-01T00:00:00Z","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), runtime.Compiler),
+		},
+		"gitversion override": {
+			gitversion: "override",
+			exp:        fmt.Sprintf(`{"GitVersion":"override","GitCommit":"dev","BuildDate":"1970-01-01T00:00:00Z","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), runtime.Compiler),
+		},
+		"gitcommit override": {
+			gitcommit: "override",
+			exp:       fmt.Sprintf(`{"GitVersion":"dev","GitCommit":"override","BuildDate":"1970-01-01T00:00:00Z","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), runtime.Compiler),
+		},
+		"builddate override": {
+			builddate: "override",
+			exp:       fmt.Sprintf(`{"GitVersion":"dev","GitCommit":"dev","BuildDate":"override","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), runtime.Compiler),
+		},
+		"all values override": {
+			gitversion: "override",
+			gitcommit:  "override",
+			builddate:  "override",
+			exp:        fmt.Sprintf(`{"GitVersion":"override","GitCommit":"override","BuildDate":"override","GoVersion":"%s","Platform":"%s","Compiler":"%s"}`, runtime.Version(), fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), runtime.Compiler),
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			res := versionStringWithOverrides(tc.gitversion, tc.gitcommit, tc.builddate)
+
+			if res != tc.exp {
+				t.Errorf("Exp res to be '%s', got '%s'", tc.exp, res)
+			}
+
+			// check if the result is a valid json
+			js := json.RawMessage{}
+			if err := json.Unmarshal([]byte(res), &js); err != nil {
+				t.Errorf("Exp to unmarshal version string without error, but got '%v'", err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Add version command which gives details about the build.

In addition this PR also adds the required ldflags for goreleaser, so new binaries have this info embedded.

fixes: #38 