### PR TITLE
doc fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -164,11 +164,3 @@ If you want to only run integration tests, simply run:
 ```sh
 go test -run Integration ./...
 ```
-
-## Ideas for Future Improvements
-
-- Make it work for fish
-- Allow usage of other fuzzy finders like fzf
-- `konf manage` so you can rename contexts and clusters
-- `konf delete` option so you can delete konfs you don't need anymore
-- File column could be improved by either using '...' abreviation or filtering out the konfDir

--- a/Readme.md
+++ b/Readme.md
@@ -52,10 +52,13 @@ nix-shell -p konf
 For NixOS users it is highly recommended to install the package by adding it to the list of `systemPackages`.
 
 ```nix
-environment.systemPackages = with pkgs; [
-  konf
-  # ...
-];
+{ # ...
+
+  environment.systemPackages = with pkgs; [
+    konf
+    # ...
+  ];
+}
 ```
 
 #### 1.3 Building from source

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ nix-env -iA nixpkgs.konf
 
 For adhoc or testing purposes a shell with the package can be spawned.
 
-```
+```shell
 nix-shell -p konf
 ```
 


### PR DESCRIPTION
Removes the future ideas section, as these have been created as GH issues.

In addition this slightly extends the nix code block, to fix GH's syntax highlighting. Taken from [nixpkgs documentation](https://github.com/NixOS/nixpkgs/blob/d917c76850c20ad8cd181d3e5d630c353d8eb549/doc/languages-frameworks/lua.section.md?plain=1#L66-L73)

**before**
![image](https://user-images.githubusercontent.com/20774623/192135907-16848d10-f0b6-432f-92c5-d6f3971dc577.png)

**after**
![image](https://user-images.githubusercontent.com/20774623/192135919-84d9b4bd-5d4f-4592-86fb-c942d1431b4a.png)
