### PR TITLE
fix: changelog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # we need this, so GoReleaser has access to the whole history for generating changelog
       - name: Setup go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
With this commit the changelog will be generated correctly if multiple commits are between two versions. Refer to https://goreleaser.com/errors/no-history/