### PR TITLE
doc: fix open last konf on new shell session

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,7 +89,7 @@ A collection of optional settings to improve quality of life with konf. These ca
 source <(konf completion zsh)
 
 # Open last konf on new shell session
-export KUBECONFIG=$(konf --silent set -)
+konf --silent set -
 
 # Alias
 alias kctx="konf set"


### PR DESCRIPTION
The `konf --silent set -` call does not print to standard out, which sets the KUBECONFIG variable to an empty string. Which in turn *does not* open the last konf.